### PR TITLE
#159250151 Managers can delete or deactive trainers from a gym

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -26,6 +26,8 @@
     <th style="width: 10%;">{% trans "ID" %}</th>
     <th style="width: 40%;">{% trans "Username" %}</th>
     <th>{% trans "Name" %}</th>
+    <th>{% trans "Active" %}</th>
+    <th>{% trans "Action" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         <th style="text-align: right;">{% trans "Roles" %}</th>
     {% endif %}
@@ -38,7 +40,9 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
@@ -53,10 +57,23 @@
         {% endif %}
     </td>
     <td>
-        {{current_user.obj.get_full_name}}
+        {% if current_user.obj.is_active %}
+        <span>Yes</span>
+        {% else %}
+        <span>No</span>
+        {% endif %}
     </td>
 
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+    <td>
+        {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+        {% if current_user.obj.is_active %}
+        <a href="{% url 'core:user:deactivate' current_user.obj.pk %}" style="color:#ffcc00">Deactivate</a>
+        {% else %}
+        <a href="{% url 'core:user:activate' current_user.obj.pk %}" style="color:#00e64d">Activate</a>
+        {% endif %}
+        {% endif %}
+    </td>
     <td style="text-align: right;">
         <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
             <span class="{% fa_class 'cog' %}"></span>


### PR DESCRIPTION
#### What does this PR do?
Allows managers to be able to delete or deactivate trainers in their various gyms

#### Description of Task to be completed?
Currently, managers cannot delete or deactivate trainers from a gym. They should be able to do this.

The Gym administrator has access only to his gym members.
The General manager, on the other hand, has access to all gyms and their members.

#### How should this be manually tested?
1.  After cloning the repo, cd into the project and run ```python manage.py runserver```.
2. Login in as admin to be able to view  or create the gyms.
3. Under the``` admin``` drop-down, choose gyms.
4. Add a new gym and create new members in it. Make any of the members ```Gym administrator``` or ```'General manager ``` and explore their different access levels.

#### What are the relevant pivotal tracker stories?
[#159250151](https://www.pivotaltracker.com/story/show/159250151)

#### Screenshots 
![image](https://user-images.githubusercontent.com/31403932/43775305-e14cdd84-9a54-11e8-9c93-4b4b525173ce.png)

![image](https://user-images.githubusercontent.com/31403932/43775537-c8ea3d76-9a55-11e8-9749-f95ff46398ea.png)

![image](https://user-images.githubusercontent.com/31403932/43775673-363b4852-9a56-11e8-86a3-3b629d6686a7.png)

![image](https://user-images.githubusercontent.com/31403932/43775692-44d068de-9a56-11e8-9087-1d5054598019.png)
