### PR TITLE
#159250136 Show all info when using exercises API endpoint

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -25,12 +25,31 @@ from wger.exercises.models import (
 )
 
 
+class MuscleSerializer(serializers.ModelSerializer):
+    '''
+    Muscle serializer
+    '''
+
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Muscle
+
+    def get_image_url(self, obj):
+        return 'images/muscles/main/muscle-%s.svg' % obj.id
+
+
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
+    muscles = MuscleSerializer(read_only=True, many=True)
+    muscles_secondary = MuscleSerializer(read_only=True, many=True)
+
     class Meta:
+        depth = 2
         model = Exercise
+
 
 
 class EquipmentSerializer(serializers.ModelSerializer):
@@ -63,11 +82,3 @@ class ExerciseCommentSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = ExerciseComment
-
-
-class MuscleSerializer(serializers.ModelSerializer):
-    '''
-    Muscle serializer
-    '''
-    class Meta:
-        model = Muscle


### PR DESCRIPTION
#### What does this PR do?
Implements an API endpoint to return all information for an exercise

#### Description of Task to be completed?
Implement a new read-only API endpoint that includes information on muscles, category, images, license. A client should be able to get all the information for an exercise in a single request.

#### How should this be manually tested?
After cloning this repository;
- run the command `python manage.py runserver`
- test API endpoint `/api/v2/exercises/` using a client such as curl, Postman, http pie

#### What are the relevant pivotal tracker stories?
[#159250136](https://www.pivotaltracker.com/story/show/159250136)

#### Screenshots 
- Testing `new` exercise API endpoint using Postman

<img width="1430" alt="screen shot 2018-08-08 at 15 19 39" src="https://user-images.githubusercontent.com/4680759/43836619-9917c1e4-9b1e-11e8-93bc-7c5d5683e3df.png">

<img width="1436" alt="screen shot 2018-08-08 at 15 23 12" src="https://user-images.githubusercontent.com/4680759/43836751-070a6f94-9b1f-11e8-9897-53cb306d0c52.png">

- Testing `old` exercise API endpoint

<img width="1432" alt="screen shot 2018-08-08 at 12 49 13" src="https://user-images.githubusercontent.com/4680759/43830305-abe299b2-9b09-11e8-9387-aa9b6859912d.png">

<img width="1434" alt="screen shot 2018-08-08 at 12 50 13" src="https://user-images.githubusercontent.com/4680759/43830306-ac0ca5b8-9b09-11e8-82c4-1b3cc39223e0.png">