### PR TITLE
#159729550 Ensure endpoint in #159250136 is read-only 

### DIFF
--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -53,6 +53,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
     queryset = Exercise.objects.all()
     serializer_class = ExerciseSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
+    http_method_names = ['get', 'options', 'head']
     ordering_fields = '__all__'
     filter_fields = ('category',
                      'creation_date',


### PR DESCRIPTION
#### What does this PR do?
Ensures that `/api/v2/exercises/` endpoint is read-only

#### Description of Task to be completed?
The task involves restricting the HTTP methods allowed to only GET, HEAD and OPTIONS

#### How should this be manually tested?
After cloning this repository;
- run the command `python manage.py runserver`
- test API endpoint `/api/v2/exercise/` using a client such as curl, Postman, http pie

#### Any background context you want to provide?
The exercises endpoint created in story [#159250136](https://www.pivotaltracker.com/story/show/159250136) should be read-only i.e. it should not allow methods such as POST, PUT, UPDATE or DELETE

#### What are the relevant pivotal tracker stories?
- [#159729550](https://www.pivotaltracker.com/story/show/159729550): Ensure endpoint in #159250136 is read-only 
- [#159250136](https://www.pivotaltracker.com/story/show/159250136) : Show all infos for an exercise

#### Screenshots (if appropriate)
<img width="849" alt="screen shot 2018-08-13 at 15 31 57" src="https://user-images.githubusercontent.com/4680759/44031892-13077c5e-9f0e-11e8-90c8-81b1e0881186.png">
