### PR TITLE
#159250148 Change how meal is added

### DIFF
--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -25,7 +25,7 @@ from wger.nutrition.models import (
     Ingredient,
     MealItem
 )
-from wger.utils.widgets import Html5NumberInput
+from wger.utils.widgets import Html5NumberInput, Html5TimeInput
 
 
 logger = logging.getLogger(__name__)
@@ -150,3 +150,19 @@ class MealItemForm(forms.ModelForm):
             self.fields['weight_unit'].queryset = \
                 IngredientWeightUnit.objects.filter(
                     ingredient_id=ingredient_id)
+
+
+class ChoiceFieldCustom(forms.ChoiceField):
+    def validate(self, value):
+        pass
+
+
+class MealCreateForm(forms.Form):
+    ingredient = forms.CharField()
+    time = forms.TimeField(widget=Html5TimeInput(), label=' Time ')
+    weight_unit = ChoiceFieldCustom(
+        choices=IngredientWeightUnit.objects.none(),
+        required=False)
+    amount = forms.DecimalField(decimal_places=2,
+                                max_digits=6, label='Amount',
+                                widget=Html5NumberInput())

--- a/wger/nutrition/templates/meal/add.html
+++ b/wger/nutrition/templates/meal/add.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load wger_extras %}
+
+
+{% block title %}{% trans "Add new meal" %}{% endblock %}
+
+
+{% block header %}
+<script type="text/javascript">
+$(document).ready(function() {
+    // Init the autocompleter
+    wgerInitIngredientAutocompleter();
+});
+</script>
+{% endblock %}
+
+
+
+
+{% block content %}
+
+<form action="{{ form_action }}"
+      method="post"
+      class="form-horizontal">
+    {% csrf_token %}
+    {% render_form_errors form %}
+
+    <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
+        <label for="id_ingredient_searchfield" class="col-md-3 control-label">
+            {% trans "Ingredient name" %}
+        </label>
+
+        <div class="col-md-9">
+            <input type="text"
+                   id="id_ingredient_searchfield"
+                   name="ingredient"
+                   value="{{ingredient_searchfield}}"
+                   class="form-control">
+            <div id="exercise_name"></div>
+        </div> 
+    </div>
+    {% render_form_field form.time %}
+    {% render_form_field form.amount %}
+    {% render_form_field form.weight_unit %}
+    {% render_form_submit submit_text %}
+</form>
+{% endblock %}

--- a/wger/nutrition/templates/plan/view.html
+++ b/wger/nutrition/templates/plan/view.html
@@ -133,7 +133,7 @@ function wgerCustomModalInit()
 {% empty %}
 {% if is_owner %}
 <p>
-     <a href="{% url 'nutrition:meal:add' plan.id %}"
+     <a href="{% url 'nutrition:meal:add_edit' plan.id %}"
         class="wger-modal-dialog btn btn-default btn-block">
             {% trans "No meals for this plan." %}
             {% trans "Add one now." %}
@@ -144,7 +144,7 @@ function wgerCustomModalInit()
         {% if is_owner %}
         <tr>
             <td colspan="6">
-            <a href="{% url 'nutrition:meal:add' plan.id %}"
+            <a href="{% url 'nutrition:meal:add_edit' plan.id %}"
                class="wger-modal-dialog">
                 <span class="{% fa_class 'plus' %}"></span>
                 {% trans "Add a new meal" %}

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -21,10 +21,9 @@ from wger.core.tests import api_base_test
 from wger.core.tests.base_testcase import (
     WorkoutManagerTestCase,
     WorkoutManagerEditTestCase,
-    WorkoutManagerAddTestCase
+    WorkoutManagerAddTestCase,
 )
-from wger.nutrition.models import Meal
-from wger.nutrition.models import NutritionPlan
+from wger.nutrition.models import Meal, NutritionPlan, MealItem
 
 
 class MealRepresentationTestCase(WorkoutManagerTestCase):
@@ -60,6 +59,35 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
     data = {'time': datetime.time(9, 2)}
     user_success = 'test'
     user_fail = 'admin'
+
+
+class AddMealAndItemTestCase(WorkoutManagerTestCase):
+    """
+    Tests adding a meal and meal item at once
+    """
+    def setUp(self):
+        super(AddMealAndItemTestCase, self).setUp()
+        self.user_login('admin')
+        self.url = reverse('nutrition:meal:add_edit', kwargs={'plan_pk': 4})
+        self.form = {"time": datetime.time(23, 2),
+                     "amount": 940,
+                     "ingredient": "Test ingredient 1",
+                     "weight_unit": 3}
+
+    def test_it_loads(self):
+        """
+        Test that it loads add meal modal
+        """
+        response = self.client.get(self.url)
+        self.assertIn(b"Ingredient name", response.content)
+
+    def test_add_meal_item(self):
+        """
+        Test that it redirects after adding meal item
+        """
+        self.client.post(self.url, self.form)
+        meal = MealItem.objects.filter(amount=940)
+        self.assertEqual(len(meal), 1)
 
 
 class PlanOverviewTestCase(WorkoutManagerTestCase):

--- a/wger/nutrition/urls.py
+++ b/wger/nutrition/urls.py
@@ -72,6 +72,9 @@ patterns_meal = [
     url(r'^(?P<id>\d+)/delete/$',
         meal.delete_meal,
         name='delete'),
+    url(r'^(?P<plan_pk>\d+)/meal/add_edit/$',
+        meal.add_meal,
+        name='add_edit')
 ]
 
 


### PR DESCRIPTION
### What does this PR do?
Changes the way the user adds meals 

 ### Description of Task to be completed?
When the user tries to make a nutrition plan, it is a bit uncomfortable to add a time for the meal and then have to add the food at that meal.
It will be better to set everything at once (time, ingredient and amount). 

### How should this be manually tested?
After cloning this repository;

Run the following commands
python manage.py runserver
log in as an admin
Navigate to ```Nutrition```
Navigate to ```Nutrition plans```
Click ```Add nutrition plan```
Click ```Add a new meal```
In the ```Ingredient name field ``` type chocolate and select one of the options returned
Set the time on the time field using the 24-hour system
Add the amount of the meal item
In the weight-unit field select a unit from the list
click ```Save```

### What are the relevant pivotal tracker stories?
[#159250148](https://www.pivotaltracker.com/story/show/159250148)

#### Screenshots
![image](https://user-images.githubusercontent.com/30747298/44082563-4a98bece-9fba-11e8-8e35-27d470301221.png)
