### PR TITLE
#159250134 Differentiate inactive and active users in a gym.

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -68,7 +68,7 @@
     <td>
         {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
         {% if current_user.obj.is_active %}
-        <a href="{% url 'core:user:deactivate' current_user.obj.pk %}" style="color:#ffcc00">Deactivate</a>
+        <a href="{% url 'core:user:deactivate' current_user.obj.pk %}" style="color:rgb(206, 20, 20)">Deactivate</a>
         {% else %}
         <a href="{% url 'core:user:activate' current_user.obj.pk %}" style="color:#00e64d">Activate</a>
         {% endif %}

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -6,49 +6,107 @@
 <script>
 $(document).ready( function () {
     /* Make table sortable */
-    $('#main_member_list').DataTable({
+    $('#main_active_member_list', '#main_inactive_member_list').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
     });
 });
 </script>
-
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
-</table>
+<h4>{% trans "Users" %}</h4>
+<ul class="nav nav-tabs" role="memberlist">
+    <li class="nav-item active">
+      <a class="nav-link " data-toggle="tab" href="#active-members">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" data-toggle="tab" href="#inactive-members">Inactive</a>
+    </li>
+</ul>
+<div class="tab-content">
+    <!--Active-members-list-->
+    <div id="active-members" class="tab-pane active">
+        <table class="table table-hover" id="main_active_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
+                </td>
+                {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <!--Inactive-members-List-->
+    <div id="inactive-members" class="tab-pane fade">
+        <table class="table table-hover" id="#main_inactive_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if not current_user.obj.is_active %}
+                <tr>
+                    <td>
+                        {{current_user.obj.pk}}
+                    </td>
+                    <td>
+                        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                    </td>
+                    <td>
+                        {{current_user.obj.get_full_name}}
+                    </td>
+                    <td data-order="{{current_user.last_log|date:'U'}}">
+                        {{current_user.last_log|default:'-/-'}}
+                    </td>
+                    {% if show_gym %}
+                    <td>
+                        {% if current_user.obj.userprofile.gym_id %}
+                            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                            {{ current_user.obj.userprofile.gym }}
+                            </a>
+                        {% else %}
+                            -/-
+                        {% endif %}
+                    </td>
+                    {% endif %}
+                </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
#### What does this PR do?
Separates active users from the inactive users in the gym.

#### Description of Task to be completed?
At the moment, the only way to determine whether a gym member is active or not was to open his detail view and see their status. Now, the active users have a different tab from the inactive users, hence no need to view the detail view.

#### How should this be manually tested?
1. After cloning the repo, cd into the project and run ```python manage.py runserver```.
2. Login in as ```admin``` to be able to view or create gyms.
3. Under the ```admin``` drop-down, choose ```gyms```.
4. Add a new gym and create new ```users``` in it.
5. Deactivate some of the users and leave others active. The active users will be found under the 
     ```active tab```, the inactive users under the ```inactive tab```.

#### What are the relevant pivotal tracker stories?
[#159250134](https://www.pivotaltracker.com/story/show/159250134)

#### Screenshots
![image](https://user-images.githubusercontent.com/31403932/44156877-ac9a8ce2-a0b9-11e8-9aa8-a6dd5064fe3f.png)
![image](https://user-images.githubusercontent.com/31403932/44156899-b674c43a-a0b9-11e8-8c9f-63f85613f01e.png)


