### PR TITLE
#159250135 Cache nutritional values

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -19,3 +19,4 @@
 from wger import get_version
 
 VERSION = get_version()
+default_app_config = 'wger.nutrition.apps.NutritionPlanValuesConfig'

--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class NutritionPlanValuesConfig(AppConfig):
+    name = 'wger.nutrition'
+    verbose_name = "NutritionPlan"
+
+    def ready(self):
+        import wger.nutrition.signals  # noqa F401

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -112,52 +112,63 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        # query for the cache
+        nutritional_plan_values_canonical_form = cache.get(
+            cache_mapper.get_nutritional_plan_canonical(self.pk)
+        )
+        # check if cache exit
+        if not nutritional_plan_values_canonical_form:
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        energy = result['total']['energy']
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] *\
-                    ENERGY_FACTOR[key][unit] / energy * 100
+            energy = result['total']['energy']
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] =\
-                    result['total'][key] / weight_entry.weight
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * \
+                        ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / \
+                        weight_entry.weight
 
-        return result
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(
+                        result[key][i]).quantize(TWOPLACES)
+            nutritional_plan_values_canonical_form = result
+            cache.set(cache_mapper.get_nutritional_plan_canonical(self.pk),
+                      nutritional_plan_values_canonical_form
+                      )
+        return nutritional_plan_values_canonical_form
 
     def get_closest_weight_entry(self):
         '''

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,22 @@
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from django.core.cache import cache
+from wger.utils.cache import cache_mapper
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_delete, sender=MealItem)
+@receiver(post_save, sender=MealItem)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+def reset_nutrional_plan_canonical(sender, **kwargs):
+    '''
+    Function to send signal
+    '''
+    instance_sender = kwargs['instance']
+    if isinstance(instance_sender, (MealItem, NutritionPlan, Meal)):
+        cache.delete(cache_mapper.get_nutritional_plan_canonical(
+            instance_sender.get_owner_object().id))

--- a/wger/nutrition/templates/plan/overview.html
+++ b/wger/nutrition/templates/plan/overview.html
@@ -6,6 +6,8 @@
 
 
 {% block content %}
+
+
 <div class="list-group">
     {% for plan in plans %}
         <a href="{{ plan.get_absolute_url }}" class="list-group-item">
@@ -15,6 +17,7 @@
             <p class="list-group-item-text">
                 {{ plan.creation_date }} –
                 {{ plan.get_nutritional_values.total.energy|floatformat }} {% trans "kcal" %}
+
             </p>
         </a>
     {% empty %}
@@ -24,6 +27,8 @@
         </a>
     {% endfor %}
 </div>
+
+
 {% endblock %}
 
 

--- a/wger/nutrition/tests/test_nutritional_plan_values.py
+++ b/wger/nutrition/tests/test_nutritional_plan_values.py
@@ -1,0 +1,54 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+from django.core.cache import cache
+
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+
+
+class NutritionPlanCacheTestCase(WorkoutManagerTestCase):
+    '''
+    Test case for the NutritionalPlan canonical representation
+    '''
+    def test_nutritional_plan_canonical_form_cache(self):
+        '''
+        Test that the nuttritional plan cache is correctly generated
+        '''
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+    def test_nutritional_plan_canonical_form_cache_save(self):
+        '''
+        Tests the nutritional_plan values cache when saving a nutritional plan
+        '''
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+        nutritional_plan.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+    def test_nutritional_plan_canonical_form_cache_delete(self):
+        '''
+        Tests the nutrional plan values cache when deleting
+        '''
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+        nutritional_plan.delete()
+        self.assertFalse(cache.get(cache_mapper.get_workout_canonical(1)))

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -66,8 +66,8 @@ def overview(request):
     template_data.update(csrf(request))
 
     plans = NutritionPlan.objects.filter(user=request.user)
-    template_data['plans'] = plans
 
+    template_data['plans'] = plans
     return render(request, 'plan/overview.html', template_data)
 
 

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -68,6 +68,9 @@ class CacheKeyMapper(object):
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
 
+    NUTRITION_PLAN_VALUES_CANONICAL_REPRESENTATION = 'nutritional-plan-values-canonical-\
+    representation-{0}'
+
     def get_pk(self, param):
         '''
         Small helper function that returns the PK for the given parameter
@@ -114,6 +117,13 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutritional_plan_canonical(self, param):
+        '''
+        Return the nutritional plan canonical representation
+        '''
+        return self.NUTRITION_PLAN_VALUES_CANONICAL_REPRESENTATION.format(
+            self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?
Caching of nutritional values to reduce render time

#### Description of Task to be completed?
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

#### How should this be manually tested?;
- Clone the repository 
- Run  `python manage.py runserver`
- Go to the nutritions section.
- Click the nutritions plan.
- Add 25 meals to the nutrition plan.
- Open the developer console.
- There is a difference in time taken to load before and after clearing the cache.


#### What are the relevant pivotal tracker stories?
[#159250135 ](https://www.pivotaltracker.com/story/show/159250135)

#### Screenshots
- Before clearing the cache
<img width="1439" alt="screen shot 2018-08-16 at 20 57 10" src="https://user-images.githubusercontent.com/39955301/44225775-0755d780-a197-11e8-8807-d37a7d779f4a.png">



- After clearing the cache
<img width="1433" alt="screen shot 2018-08-16 at 20 56 58" src="https://user-images.githubusercontent.com/39955301/44225790-12a90300-a197-11e8-82e2-a0cb223e42c5.png">
