### PR TITLE
#159728034 Plain text passwords should not be visible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-fitbit==0.3.0
 django-formtools==1.0
 django-mobile==0.7.0
 django-recaptcha==1.3.1
+django-sendgrid-v5==0.6.893
 django-sortedm2m==1.5.0
 django-tastypie==0.14.1
 djangorestframework==3.2.5
@@ -47,6 +48,7 @@ PyJWT==1.6.4
 pyparsing==2.2.0
 python-dateutil==2.7.3
 python-decouple==3.1
+python-http-client==3.1.0
 python-mimeparse==1.6.0
 python3-openid==3.1.0
 pytz==2018.5
@@ -56,6 +58,7 @@ requests==2.19.1
 requests-mock==1.5.2
 requests-oauthlib==1.0.0
 rjsmin==1.0.12
+sendgrid==5.5.0
 simplejson==3.16.0
 six==1.11.0
 snowballstemmer==1.2.1

--- a/settings.py
+++ b/settings.py
@@ -59,7 +59,9 @@ ALLOWED_HOSTS = '*'
 
 # Configure a real backend in production
 if DEBUG:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    EMAIL_BACKEND = os.environ.get(
+                            'EMAIL_BACKEND',
+                            'django.core.mail.backends.console.EmailBackend')
 
 # Sender address used for sent emails
 WGER_SETTINGS['EMAIL_FROM'] = 'wger Workout Manager <wger@example.com>'  # noqa E405

--- a/wger/core/api/serializers.py
+++ b/wger/core/api/serializers.py
@@ -32,6 +32,7 @@ class UserSerializer(serializers.ModelSerializer):
     """User Serializer"""
     class Meta:
         model = User
+        fields = ("email", "username", "password")
 
 
 class UserprofileSerializer(serializers.ModelSerializer):

--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -58,9 +58,9 @@ class UserPreferencesForm(forms.ModelForm):
 class UserEmailForm(forms.ModelForm):
     email = EmailField(
         label=_("Email"),
-        help_text=_("Used for password resets and,\
-                       optionally, email reminders."),
-        required=False)
+        help_text=_("Used to set and reset passwords and\
+                       optionally, set email reminders."),
+        required=True)
 
     class Meta:
         model = User

--- a/wger/core/tests/test_preferences.py
+++ b/wger/core/tests/test_preferences.py
@@ -73,7 +73,7 @@ class PreferencesTestCase(WorkoutManagerTestCase):
         response = self.client.post(reverse('core:user:preferences'),
                                     {'show_comments': False,
                                      'show_english_ingredients': True,
-                                     'email': '',
+                                     'email': 'another-email@example.com',
                                      'workout_reminder_active': True,
                                      'workout_reminder': 22,
                                      'workout_duration': 10,
@@ -88,7 +88,8 @@ class PreferencesTestCase(WorkoutManagerTestCase):
         profile = response.context['user'].userprofile
         self.assertFalse(profile.show_comments)
         self.assertTrue(profile.show_english_ingredients)
-        self.assertEqual(response.context['user'].email, '')
+        self.assertEqual(response.context['user'].email,
+                         'another-email@example.com')
 
     def test_address(self):
         '''

--- a/wger/gym/templates/gym/new_gym_member.tpl
+++ b/wger/gym/templates/gym/new_gym_member.tpl
@@ -1,0 +1,11 @@
+{% load i18n %}{% blocktrans %}You are a now a member of '{{gym}}'.{% endblocktrans %}
+
+{% blocktrans %}Login credentials{% endblocktrans %}
+
+{% blocktrans %}Your username is {{ username }}{% endblocktrans %}
+
+{% blocktrans %}Your password is {{ pass_key }}{% endblocktrans %}
+
+{% blocktrans %} Follow this link to login: {{ url }} {% endblocktrans %}
+
+{% blocktrans %} Thank you, Wger team {% endblocktrans %}

--- a/wger/gym/templates/gym/new_user.html
+++ b/wger/gym/templates/gym/new_user.html
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <th>{% trans "Password" %}</th>
-        <td>{{password}}</td>
+        <td>-- Sent to user's email --</td>
     </tr>
     <tr>
         <th>{% trans "Email" %}</th>
@@ -38,19 +38,9 @@
 {% endblock %}
 
 
-
-
 {% block sidebar %}
 <h4>{% trans "Info" %}</h4>
 <p>
-    {% blocktrans %}Please write down the user password or save the exported
-file, which contains all the user data, and keep it in a safe place. The password
-cannot be recovered later.{% endblocktrans %}
-</p>
-
-<p>
-    <a href="{% url 'gym:gym:new-user-data-export' %}" {% auto_link_css flavour %}>
-        {% trans "Export user data" %}
-    </a>
+    {% blocktrans %}The new user can now check their email to access their credentials {% endblocktrans %}
 </p>
 {% endblock %}

--- a/wger/gym/tests/test_user.py
+++ b/wger/gym/tests/test_user.py
@@ -18,6 +18,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
+from django.core import mail
 
 from wger.core.models import UserProfile
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
@@ -67,6 +68,9 @@ class GymAddUserTestCase(WorkoutManagerTestCase):
                                         ['user_pk'])
             self.assertEqual(GymAdminConfig.objects.all().count(), 1)
             self.assertEqual(new_user.userprofile.gym_id, 1)
+
+            # Check that email is sent
+            self.assertEqual(len(mail.outbox), 1)
 
     def test_add_user_authorized(self):
         '''

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -392,8 +392,9 @@ class GymAddUserView(WgerFormMixin,
         if 'manager' in form.cleaned_data['role']:
             user.groups.add(Group.objects.get(name='general_gym_manager'))
 
-        self.request.session['gym.user'] = {'user_pk': user.pk,
-                                            'password': password}
+        request = self.request
+        request.session['gym.user'] = {'user_pk': user.pk,
+                                       'password': password}
 
         # Create config
         if is_any_gym_admin(user):
@@ -404,6 +405,8 @@ class GymAddUserView(WgerFormMixin,
         config.user = user
         config.gym = gym
         config.save()
+
+        form.send_email(request, user, gym)
 
         return super(GymAddUserView, self).form_valid(form)
 

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -203,8 +203,14 @@ STATICFILES_FINDERS = (
 # Email
 #
 EMAIL_SUBJECT_PREFIX = '[wger] '
-# EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
+EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
+EMAIL_HOST = 'smtp.sendgrid.net'
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
+SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 
 #
 # Login


### PR DESCRIPTION
#### What does this PR do?
It makes passwords of new users invisible to administrators. Instead, new users should receive their passwords via email

#### Description of Task to be completed?
As part of the task, passwords for new users in the dashboard should be hidden from administrators
The system should send an email to the newly created user's email with a password

#### How should this be manually tested?;
- Clone repository by running `git clone -b ch-make-user-passwords-invisible-159728034 https://github.com/andela/wg-aces.git` in your terminal
- Run `pip install -r requirements.txt` to install necessary project dependencies
- Enter the command `./manage.py runserver` to launch the application 
- Login with the `Administrator` account or any account that has permissions to add a user to a gym
- Access `Gyms` under the `Administrator` dropdown menu on the right
- Add a new user to any existing gym, you may create a new gym if none exists
- On creation of new user, password is sent to the email provided and should not be displayed to an administrator

#### What are the relevant pivotal tracker stories?
[#159728034](https://www.pivotaltracker.com/story/show/159728034)

#### Screenshots
- Confirmation page for adding new user
<img width="1291" alt="screen shot 2018-08-22 at 13 16 22" src="https://user-images.githubusercontent.com/4680759/44458058-ac483880-a60d-11e8-87b0-243ea88e0c51.png">


- Register Page indicating entry of an email as compulsory
<img width="1080" alt="screen shot 2018-08-22 at 11 32 07" src="https://user-images.githubusercontent.com/4680759/44452461-42289700-a5ff-11e8-98a1-ffb7cab3a9a3.png">


