### PR TITLE
#159250145 Move away from Transifex proprietary software

### DIFF
--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -143,9 +143,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                                    <a href="https://translate.zanata.org/iteration/view/wg-aces/version_1.0?dswid=3911">
                                         <span class="fa fa-external-link" aria-hidden="true"></span>
-                                        {% trans "Translate with Transifex" %}
+                                        {% trans "Translate with Zanata" %}
                                     </a>
                                 </li>
                             </ul>
@@ -252,4 +252,3 @@
         </div>
     </div>
 </nav>
-

--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -96,7 +96,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.transifex.com/rge/wger-workout-manager/" title="{% trans 'Translate' %}">
+                        <a href="https://translate.zanata.org/iteration/view/wg-aces/version_1.0?dswid=3911" title="{% trans 'Translate' %}">
                             <span class="{% fa_class 'globe' %}"></span>
                         </a>
                     </li>

--- a/wger/software/templates/contribute.html
+++ b/wger/software/templates/contribute.html
@@ -75,11 +75,11 @@ is too short or some other detail is missing or could be improved, tell!{% endbl
         <p>{% blocktrans %}Do you want to use wger in your own language?
 Do you think the current translation could be improved?
 The translations are easily managed and edited online, if you are interested,
-go to the transifex site, request access and we will set everything
+go to the zanata site, request access and we will set everything
 up. {% endblocktrans %}</p>
 
         <a class="btn btn-default"
-           href="https://www.transifex.com/rge/wger-workout-manager/">{% trans "Translate with Transifex" %} »</a>
+           href="https://translate.zanata.org/iteration/view/wg-aces/version_1.0?dswid=3911">{% trans "Translate with Zanata" %} »</a>
     </div>
 </div>
 


### PR DESCRIPTION
### What does this PR do?
Move translation support away from proprietary Transifex software to an open source alternative

### Description of Task to be completed?
Setup application with an alternative translation software that is free to use.

 ### How should this be manually tested?
After cloning the repository to a local machine,
- Run the application in the terminal with the command `./manage.py runserver`
- In the navigation, click drop-down option labeled `About this software` and select the option `Translate with Zanata`
- This opens the Wger translation project on `zanata.org` where you can select a `language of choice` to add translations for. 

### Any background context you want to provide?
Translations are obtained from Transifex, a platform for community-based translation. Translation files (.po files)  generated by django are uploaded to the service where required translations can be adding them back to the project 

The translation project on zanata.org can be found [here](https://translate.zanata.org/iteration/view/wg-aces/version_1.0?dswid=8357)

### Screenshots
- Wger translation profile on zanata.org
<img width="1348" alt="screen shot 2018-08-24 at 18 04 16" src="https://user-images.githubusercontent.com/4680759/44593330-c0d22f80-a7cb-11e8-8793-6a5dff66cb99.png">

- Adding translations 
<img width="1426" alt="screen shot 2018-08-24 at 18 34 36" src="https://user-images.githubusercontent.com/4680759/44593643-a77db300-a7cc-11e8-8dfc-0fcb37ef7acd.png">
