### PR TITLE
#159250143 Allow comparison of gym-users

### DIFF
--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -65,6 +65,7 @@
     <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'bower_components/Sortable/Sortable.min.js' %}"></script>
     <script src="{% static 'bower_components/d3/d3.js' %}"></script>
+    <script src="{% static 'bower_components/chart.js/dist/Chart.min.js' %}"></script>
     <script src="{% static 'bower_components/metrics-graphics/dist/metricsgraphics.min.js' %}"></script>
     <script src="{% static 'bower_components/devbridge-autocomplete/dist/jquery.autocomplete.min.js' %}"></script>
     <script src="{% static 'js/wger-core.js' %}"></script>

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -88,6 +88,124 @@
 {% endfor %}
 </tbody>
 </table>
+<!-- error message modal -->
+<div class="modal fade" role="dialog" aria-hidden="true" id="error-no-users-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>Error</h4>
+            </div>
+            <div class="modal-body">
+                <h4 class="modal-title" id="msg">Please choose users first before clicking</h4>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+
+    </div>
+</div>
+<!--End of error message modal-->
+
+<!-- charts modal -->
+<div id="compare-users-modal" class="modal fade bs-example-modal-lg" role="dialog">
+    <div class="modal-dialog modal-lg" role="dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>User weights comparison</h4>
+            </div>
+            <div class="modal-body">
+                <canvas id="comparison-canvas"></canvas>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!--End of charts modal-->
+
+<script>
+        var selectedUsers = [];
+        function selectUser(event, id) {
+          if (event.checked === true) {
+            selectedUsers.push(id);
+          } else {
+            selectedUsers.pop(id);
+          }
+        }
+         function compareUsers(event) {
+          if (selectedUsers.length === 0) {
+            $("#error-no-users-modal").modal("show");
+            return;
+          }
+          var users = selectedUsers.join(",");
+          var colors = [
+              "#800000",
+              "#FF0000",
+              "#00FFFF",
+              "#FF00FF",
+              "#000000",
+              "#FFFF00",
+              "#008000",
+              "#0000A0",
+              "#FFB81D",
+              "#AA0050",
+            ];
+          var url = "/weight/api/users_weight_data/?users=" + users
+          $.ajax({
+            url: url,
+            type: "GET",
+            success: function (response) {
+              var chartData = response.data.map(function (data, index) {
+                return {
+                  label: data.label,
+                  data: data.data,
+                  fill: false,
+                  backgroundColor: colors[index],
+                  borderColor: colors[index],
+                  borderWidth: 3
+                };
+              });
+              chartLabels = response.labels.filter(function (elem, index, self) {
+                return index === self.indexOf(elem);
+              });
+              chartLabels = chartLabels.reverse();
+              var ChartData = {
+                labels: chartLabels,
+                datasets: chartData
+              };
+               var chartOptions = {
+                responsive: true,
+                // legend: {
+                //   position: "top"
+                // },
+                title: {
+                  display: true,
+                  text: "Weight Data against days:"
+                },
+                scales: {
+                  yAxes: [
+                    {
+                      ticks: {
+                        beginAtZero: false
+                      }
+                    }
+                  ]
+                }
+              };
+              //creating the chart
+              var ctx = document.getElementById("comparison-canvas").getContext("2d");
+              var myLineChart = new Chart(ctx, {
+                type: "line",
+                data: ChartData,
+                options: chartOptions
+              });
+              $("#compare-users-modal").modal("show");
+            }
+          });
+        }
+        </script>
 {% endblock %}
 
 

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -13,6 +13,8 @@ $(document).ready( function () {
     });
 });
 </script>
+
+<button class="btn btn-primary" onClick="compareUsers()">Compare Users</button>
 <h4>{% trans "Users" %}</h4>
 <ul class="nav nav-tabs" role="memberlist">
     <li class="nav-item active">
@@ -28,6 +30,7 @@ $(document).ready( function () {
         <table class="table table-hover" id="main_active_member_list">
             <thead>
             <tr>
+                <th></th>
                 {% for key in user_table.keys %}
                     <th>{{ key }}</th>
                 {% endfor %}
@@ -37,6 +40,10 @@ $(document).ready( function () {
             {% for current_user in user_table.users %}
             {% if current_user.obj.is_active %}
             <tr>
+                <td>
+                    <input onchange="selectUser(this, `{{current_user.obj.username}}`)"
+                        name="{{current_user.obj}}"
+                        type="checkbox">
                 <td>
                     {{current_user.obj.pk}}
                 </td>

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -104,7 +104,8 @@ BOWER_INSTALLED_APPS = (
     'metrics-graphics',
     'devbridge-autocomplete#1.2.x',
     'sortablejs#1.4.x',
-    'bootstrap-social'
+    'bootstrap-social',
+    'chartjs',
 )
 
 

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -50,4 +50,7 @@ urlpatterns = [
     url(r'^api/get_weight_data/$',  # JS
         views.get_weight_data,
         name='weight-data'),
+    url(r'^api/users_weight_data/$',  # JS
+        views.get_user_weight_data,
+        name='user-weight-data-comparison'),
 ]


### PR DESCRIPTION
#### What does this PR do?
Allows comparison of two or more users in the same gym.

#### Description of Task to be completed?
When users in a gym are training together, it would be useful to see a comparison of some sorts. A possibility would be to have a graph where the data for (selected) members is shown.

This PR allows a trainer/gym admin/general manager to select two or more users and compare their weight data.

#### How should this be manually tested?
- git clone the repo and cd into the project. 
- Run ```sudo python manage.py bower_install --allow-root``` to allow ```Chartjs``` install.
- Because the ```chart``` is set to compare two or more members, the following commands help in creation of dummy data.
- Run ```cd ./extras/dummy_generator```.
- Run ```python generator.py users 6 ``` to add 6 dummy members.
- Run ```python generator.py weight 6  ``` to add 6 weights to each user.
- Run the application ```python manage.py runserver```.
- Login as ```admin``` and navigate to ```gyms```.
- In the default gym, select two or more ```users``` .
- Click the ```compare users``` button to view the results.

#### What are the relevant pivotal tracker stories?
 [#159250143](https://www.pivotaltracker.com/story/show/159250143)

#### Screenshots
New view
![image](https://user-images.githubusercontent.com/31403932/44803972-ac75a480-abc8-11e8-9ce1-e4c420399381.png)

After choosing the users to compare
![image](https://user-images.githubusercontent.com/31403932/44803991-bb5c5700-abc8-11e8-872a-66e107187631.png)

Chart comparison
![image](https://user-images.githubusercontent.com/31403932/44804008-cadba000-abc8-11e8-9d7a-44dd2247a412.png)
